### PR TITLE
Support ghc-9.10 (resolves #94).

### DIFF
--- a/chronos.cabal
+++ b/chronos.cabal
@@ -38,7 +38,7 @@ extra-doc-files:
   CHANGELOG.md
   README.md
 
-tested-with:     GHC ==9.4.8 || ==9.6.3 || ==9.8.1
+tested-with:     GHC ==9.4.8 || ==9.6.5 || ==9.8.2 || ==9.10.1
 
 common build-settings
   default-language: Haskell2010
@@ -58,7 +58,7 @@ library
   build-depends:
     , aeson               >=1.1     && <2.3
     , attoparsec          >=0.13    && <0.15
-    , base                >=4.14    && <4.20
+    , base                >=4.14    && <4.21
     , bytebuild           >=0.3.14  && <0.4
     , byteslice           >=0.2.5.2 && <0.3
     , bytesmith           >=0.3.7   && <0.4


### PR DESCRIPTION
For sure - it needs the updated `byteverse` (the diff didn't contain the allow-newer - only tested this locally - so it wouldn't build until a new `byteverse`is published or a revision ins made).