### PR TITLE
Bump upper bound of hashable dependency

### DIFF
--- a/chronos.cabal
+++ b/chronos.cabal
@@ -64,7 +64,7 @@ library
     , bytesmith           >=0.3.7   && <0.4
     , bytestring          >=0.10    && <0.13
     , deepseq             >=1.4.4.0
-    , hashable            >=1.2     && <1.5
+    , hashable            >=1.2     && <1.6
     , natural-arithmetic  >=0.1.2   && <0.3
     , primitive           >=0.6.4   && <0.10
     , text                >=1.2     && <1.3  || >=2.0 && <2.2


### PR DESCRIPTION
Allows the library to be build with `hashable ==1.5.0.0`.